### PR TITLE
Bor specific RPC method support

### DIFF
--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -1061,9 +1061,9 @@ func newSync(ctx context.Context, db kv.RwDB, miningConfig *params.MiningConfig)
 	engine = ethash.NewFaker()
 	switch chain {
 	case params.SokolChainName, params.KovanChainName:
-		engine = ethconfig.CreateConsensusEngine(chainConfig, logger, &params.AuRaConfig{DBPath: path.Join(datadir, "aura")}, nil, false, "", true)
+		engine = ethconfig.CreateConsensusEngine(chainConfig, logger, &params.AuRaConfig{DBPath: path.Join(datadir, "aura")}, nil, false, "", true, datadir)
 	case params.MumbaiChainName, params.BorMainnetChainName:
-		engine = ethconfig.CreateConsensusEngine(chainConfig, logger, chainConfig.Bor, nil, false, HeimdallURL, false)
+		engine = ethconfig.CreateConsensusEngine(chainConfig, logger, chainConfig.Bor, nil, false, HeimdallURL, false, datadir)
 	}
 
 	events := privateapi.NewEvents()

--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -215,25 +215,37 @@ func checkDbCompatibility(ctx context.Context, db kv.RoDB) error {
 	return nil
 }
 
-func RemoteServices(ctx context.Context, cfg Flags, logger log.Logger, rootCancel context.CancelFunc) (db kv.RoDB, eth services.ApiBackend, txPool *services.TxPoolService, mining *services.MiningService, stateCache kvcache.Cache, blockReader interfaces.BlockReader, err error) {
+func RemoteServices(ctx context.Context, cfg Flags, logger log.Logger, rootCancel context.CancelFunc) (db kv.RoDB, borDb kv.RoDB, eth services.ApiBackend, txPool *services.TxPoolService, mining *services.MiningService, stateCache kvcache.Cache, blockReader interfaces.BlockReader, err error) {
 	if !cfg.SingleNodeMode && cfg.PrivateApiAddr == "" {
-		return nil, nil, nil, nil, nil, nil, fmt.Errorf("either remote db or local db must be specified")
+		return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("either remote db or local db must be specified")
 	}
 
 	// Do not change the order of these checks. Chaindata needs to be checked first, because PrivateApiAddr has default value which is not ""
 	// If PrivateApiAddr is checked first, the Chaindata option will never work
 	if cfg.SingleNodeMode {
 		var rwKv kv.RwDB
+		log.Trace("Creating chain db", "path", cfg.Chaindata)
 		rwKv, err = kv2.NewMDBX(logger).Path(cfg.Chaindata).Readonly().Open()
 		if err != nil {
-			return nil, nil, nil, nil, nil, nil, err
+			return nil, nil, nil, nil, nil, nil, nil, err
 		}
 		if compatErr := checkDbCompatibility(ctx, rwKv); compatErr != nil {
-			return nil, nil, nil, nil, nil, nil, compatErr
+			return nil, nil, nil, nil, nil, nil, nil, compatErr
 		}
 		db = rwKv
 		stateCache = kvcache.NewDummy()
 		blockReader = snapshotsync.NewBlockReader()
+
+		// bor (consensus) specific db
+		var borKv kv.RoDB
+		borDbPath := path.Join(cfg.Datadir, "bor")
+		log.Trace("Creating consensus db", "path", borDbPath)
+		borKv, err = kv2.NewMDBX(logger).Path(borDbPath).Readonly().Open()
+		if err != nil {
+			return nil, nil, nil, nil, nil, nil, nil, err
+		}
+		// Skip the compatibility check, until we have a schema in erigon-lib
+		borDb = borKv
 	} else {
 		if cfg.StateCache.KeysLimit > 0 {
 			stateCache = kvcache.New(cfg.StateCache)
@@ -244,22 +256,22 @@ func RemoteServices(ctx context.Context, cfg Flags, logger log.Logger, rootCance
 	}
 
 	if cfg.PrivateApiAddr == "" {
-		return db, eth, txPool, mining, stateCache, blockReader, nil
+		return db, borDb, eth, txPool, mining, stateCache, blockReader, nil
 	}
 
 	creds, err := grpcutil.TLS(cfg.TLSCACert, cfg.TLSCertfile, cfg.TLSKeyFile)
 	if err != nil {
-		return nil, nil, nil, nil, nil, nil, fmt.Errorf("open tls cert: %w", err)
+		return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("open tls cert: %w", err)
 	}
 	conn, err := grpcutil.Connect(creds, cfg.PrivateApiAddr)
 	if err != nil {
-		return nil, nil, nil, nil, nil, nil, fmt.Errorf("could not connect to execution service privateApi: %w", err)
+		return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("could not connect to execution service privateApi: %w", err)
 	}
 
 	kvClient := remote.NewKVClient(conn)
 	remoteKv, err := remotedb.NewRemote(gointerfaces.VersionFromProto(remotedbserver.KvServiceAPIVersion), logger, kvClient).Open()
 	if err != nil {
-		return nil, nil, nil, nil, nil, nil, fmt.Errorf("could not connect to remoteKv: %w", err)
+		return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("could not connect to remoteKv: %w", err)
 	}
 
 	subscribeToStateChangesLoop(ctx, kvClient, stateCache)
@@ -271,7 +283,7 @@ func RemoteServices(ctx context.Context, cfg Flags, logger log.Logger, rootCance
 	if cfg.TxPoolV2 {
 		txpoolConn, err = grpcutil.Connect(creds, cfg.TxPoolApiAddr)
 		if err != nil {
-			return nil, nil, nil, nil, nil, nil, fmt.Errorf("could not connect to txpool api: %w", err)
+			return nil, nil, nil, nil, nil, nil, nil, fmt.Errorf("could not connect to txpool api: %w", err)
 		}
 	}
 	mining = services.NewMiningService(txpoolConn)
@@ -294,7 +306,7 @@ func RemoteServices(ctx context.Context, cfg Flags, logger log.Logger, rootCance
 			rootCancel()
 		}
 	}()
-	return db, eth, txPool, mining, stateCache, blockReader, err
+	return db, borDb, eth, txPool, mining, stateCache, blockReader, err
 }
 
 func StartRpcServer(ctx context.Context, cfg Flags, rpcAPI []rpc.API) error {

--- a/cmd/rpcdaemon/commands/bor_api.go
+++ b/cmd/rpcdaemon/commands/bor_api.go
@@ -1,0 +1,35 @@
+package commands
+
+import (
+	"github.com/ledgerwatch/erigon-lib/kv"
+	"github.com/ledgerwatch/erigon/common"
+	"github.com/ledgerwatch/erigon/consensus/bor"
+	"github.com/ledgerwatch/erigon/rpc"
+)
+
+// BorAPI Bor specific routines
+type BorAPI interface {
+	GetSnapshot(number *rpc.BlockNumber) (*Snapshot, error)
+	GetAuthor(number *rpc.BlockNumber) (*common.Address, error)
+	GetSnapshotAtHash(hash common.Hash) (*Snapshot, error)
+	GetSigners(number *rpc.BlockNumber) ([]common.Address, error)
+	GetSignersAtHash(hash common.Hash) ([]common.Address, error)
+	GetCurrentProposer() (common.Address, error)
+	GetCurrentValidators() ([]*bor.Validator, error)
+	GetRootHash(start uint64, end uint64) (string, error)
+	Test() (string, error)
+}
+
+// BorImpl is implementation of the BorAPI interface
+type BorImpl struct {
+	*BaseAPI
+	db kv.RoDB
+}
+
+// NewBorAPI returns BorImpl instance
+func NewBorAPI(base *BaseAPI, db kv.RoDB) *BorImpl {
+	return &BorImpl{
+		BaseAPI: base,
+		db:      db,
+	}
+}

--- a/cmd/rpcdaemon/commands/bor_api.go
+++ b/cmd/rpcdaemon/commands/bor_api.go
@@ -17,19 +17,20 @@ type BorAPI interface {
 	GetCurrentProposer() (common.Address, error)
 	GetCurrentValidators() ([]*bor.Validator, error)
 	GetRootHash(start uint64, end uint64) (string, error)
-	Test() (string, error)
 }
 
 // BorImpl is implementation of the BorAPI interface
 type BorImpl struct {
 	*BaseAPI
-	db kv.RoDB
+	db    kv.RoDB // the chain db
+	borDb kv.RoDB // the consensus db
 }
 
 // NewBorAPI returns BorImpl instance
-func NewBorAPI(base *BaseAPI, db kv.RoDB) *BorImpl {
+func NewBorAPI(base *BaseAPI, db kv.RoDB, borDb kv.RoDB) *BorImpl {
 	return &BorImpl{
 		BaseAPI: base,
 		db:      db,
+		borDb:   borDb,
 	}
 }

--- a/cmd/rpcdaemon/commands/bor_helper.go
+++ b/cmd/rpcdaemon/commands/bor_helper.go
@@ -1,0 +1,156 @@
+package commands
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+
+	"github.com/ledgerwatch/erigon-lib/kv"
+	"github.com/ledgerwatch/erigon/common"
+	"github.com/ledgerwatch/erigon/consensus/bor"
+	"github.com/ledgerwatch/erigon/core/rawdb"
+	"github.com/ledgerwatch/erigon/core/types"
+	"github.com/ledgerwatch/erigon/crypto"
+	"github.com/ledgerwatch/erigon/params"
+	"github.com/ledgerwatch/erigon/rpc"
+)
+
+const (
+	checkpointInterval = 1024 // Number of blocks after which vote snapshots are saved to db
+)
+
+var (
+	extraVanity = 32 // Fixed number of extra-data prefix bytes reserved for signer vanity
+	extraSeal   = 65 // Fixed number of extra-data suffix bytes reserved for signer seal
+)
+
+var (
+	// errUnknownBlock is returned when the list of signers is requested for a block
+	// that is not part of the local blockchain.
+	errUnknownBlock = errors.New("unknown block")
+
+	// errMissingSignature is returned if a block's extra-data section doesn't seem
+	// to contain a 65 byte secp256k1 signature.
+	errMissingSignature = errors.New("extra-data 65 byte signature suffix missing")
+
+	// errOutOfRangeChain is returned if an authorization list is attempted to
+	// be modified via out-of-range or non-contiguous headers.
+	errOutOfRangeChain = errors.New("out of range or non-contiguous chain")
+
+	// errMissingVanity is returned if a block's extra-data section is shorter than
+	// 32 bytes, which is required to store the signer vanity.
+	errMissingVanity = errors.New("extra-data 32 byte vanity prefix missing")
+)
+
+// getHeaderByNumber returns a block's header given a block number ignoring the block's transaction and uncle list (may be faster).
+// derived from erigon_getHeaderByNumber implementation (see ./erigon_block.go)
+func getHeaderByNumber(number rpc.BlockNumber, api *BorImpl, tx kv.Tx) (*types.Header, error) {
+	// Pending block is only known by the miner
+	if number == rpc.PendingBlockNumber {
+		block := api.pendingBlock()
+		if block == nil {
+			return nil, nil
+		}
+		return block.Header(), nil
+	}
+
+	blockNum, err := getBlockNumber(number, tx)
+	if err != nil {
+		return nil, err
+	}
+
+	header := rawdb.ReadHeaderByNumber(tx, blockNum)
+	if header == nil {
+		return nil, fmt.Errorf("block header not found: %d", blockNum)
+	}
+
+	return header, nil
+}
+
+// getHeaderByHash returns a block's header given a block's hash.
+// derived from erigon_getHeaderByHash implementation (see ./erigon_block.go)
+func getHeaderByHash(tx kv.Tx, hash common.Hash) (*types.Header, error) {
+	header, err := rawdb.ReadHeaderByHash(tx, hash)
+	if err != nil {
+		return nil, err
+	}
+	if header == nil {
+		return nil, fmt.Errorf("block header not found: %s", hash.String())
+	}
+
+	return header, nil
+}
+
+// ecrecover extracts the Ethereum account address from a signed header.
+func ecrecover(header *types.Header, c *params.BorConfig) (common.Address, error) {
+	// Retrieve the signature from the header extra-data
+	if len(header.Extra) < extraSeal {
+		return common.Address{}, errMissingSignature
+	}
+	signature := header.Extra[len(header.Extra)-extraSeal:]
+
+	// Recover the public key and the Ethereum address
+	pubkey, err := crypto.Ecrecover(bor.SealHash(header, c).Bytes(), signature)
+	if err != nil {
+		return common.Address{}, err
+	}
+	var signer common.Address
+	copy(signer[:], crypto.Keccak256(pubkey[1:])[12:])
+
+	return signer, nil
+}
+
+// validateHeaderExtraField validates that the extra-data contains both the vanity and signature.
+// header.Extra = header.Vanity + header.ProducerBytes (optional) + header.Seal
+func validateHeaderExtraField(extraBytes []byte) error {
+	if len(extraBytes) < extraVanity {
+		return errMissingVanity
+	}
+	if len(extraBytes) < extraVanity+extraSeal {
+		return errMissingSignature
+	}
+	return nil
+}
+
+// validatorContains checks for a validator in given validator set
+func validatorContains(a []*bor.Validator, x *bor.Validator) (*bor.Validator, bool) {
+	for _, n := range a {
+		if bytes.Compare(n.Address.Bytes(), x.Address.Bytes()) == 0 {
+			return n, true
+		}
+	}
+	return nil, false
+}
+
+// getUpdatedValidatorSet applies changes to a validator set and returns a new validator set
+func getUpdatedValidatorSet(oldValidatorSet *ValidatorSet, newVals []*bor.Validator) *ValidatorSet {
+	v := oldValidatorSet
+	oldVals := v.Validators
+
+	var changes []*bor.Validator
+	for _, ov := range oldVals {
+		if f, ok := validatorContains(newVals, ov); ok {
+			ov.VotingPower = f.VotingPower
+		} else {
+			ov.VotingPower = 0
+		}
+
+		changes = append(changes, ov)
+	}
+
+	for _, nv := range newVals {
+		if _, ok := validatorContains(changes, nv); !ok {
+			changes = append(changes, nv)
+		}
+	}
+
+	v.UpdateWithChangeSet(changes)
+	return v
+}
+
+// author returns the Ethereum address recovered
+// from the signature in the header's extra-data section.
+func author(api *BorImpl, tx kv.Tx, header *types.Header) (common.Address, error) {
+	config, _ := api.BaseAPI.chainConfig(tx)
+	return ecrecover(header, config.Bor)
+}

--- a/cmd/rpcdaemon/commands/bor_snapshot.go
+++ b/cmd/rpcdaemon/commands/bor_snapshot.go
@@ -1,0 +1,403 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"math/big"
+	"sync"
+
+	"github.com/ledgerwatch/erigon-lib/kv"
+	"github.com/ledgerwatch/erigon/common"
+	"github.com/ledgerwatch/erigon/consensus/bor"
+	"github.com/ledgerwatch/erigon/core/rawdb"
+	"github.com/ledgerwatch/erigon/core/types"
+	"github.com/ledgerwatch/erigon/crypto"
+	"github.com/ledgerwatch/erigon/params"
+	"github.com/ledgerwatch/erigon/rpc"
+	"github.com/xsleonard/go-merkle"
+	"golang.org/x/crypto/sha3"
+)
+
+var (
+	// errUnknownBlock is returned when the list of signers is requested for a block
+	// that is not part of the local blockchain.
+	errUnknownBlock = errors.New("unknown block")
+
+	// errMissingSignature is returned if a block's extra-data section doesn't seem
+	// to contain a 65 byte secp256k1 signature.
+	errMissingSignature = errors.New("extra-data 65 byte signature suffix missing")
+)
+
+var (
+	extraSeal = 65 // Fixed number of extra-data suffix bytes reserved for signer seal
+)
+
+type Snapshot struct {
+	config *params.BorConfig // Consensus engine parameters to fine tune behavior
+
+	Number       uint64                    `json:"number"`       // Block number where the snapshot was created
+	Hash         common.Hash               `json:"hash"`         // Block hash where the snapshot was created
+	ValidatorSet *ValidatorSet             `json:"validatorSet"` // Validator set at this moment
+	Recents      map[uint64]common.Address `json:"recents"`      // Set of recent signers for spam protections
+}
+
+type ValidatorSet struct {
+	// NOTE: persisted via reflect, must be exported.
+	Validators []*bor.Validator `json:"validators"`
+	Proposer   *bor.Validator   `json:"proposer"`
+
+	// cached (unexported)
+	totalVotingPower int64
+}
+
+// GetSnapshot retrieves the state snapshot at a given block.
+func (api *BorImpl) GetSnapshot(number *rpc.BlockNumber) (*Snapshot, error) {
+	ctx := context.Background()
+	tx, err := api.db.BeginRo(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	// Retrieve the requested block number (or current if none requested)
+	var header *types.Header
+	if number == nil || *number == rpc.LatestBlockNumber {
+		header = rawdb.ReadCurrentHeader(tx)
+	} else {
+		header, _ = getHeaderByNumber(*number, api, tx)
+	}
+	// Ensure we have an actually valid block and return its snapshot
+	if header == nil {
+		return nil, errUnknownBlock
+	}
+	return snapshot(api, tx, header.Number.Uint64(), header.Hash())
+}
+
+// GetAuthor retrieves the author a block.
+func (api *BorImpl) GetAuthor(number *rpc.BlockNumber) (*common.Address, error) {
+	ctx := context.Background()
+	tx, err := api.db.BeginRo(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	// Retrieve the requested block number (or current if none requested)
+	var header *types.Header
+	if number == nil || *number == rpc.LatestBlockNumber {
+		header = rawdb.ReadCurrentHeader(tx)
+	} else {
+		header, _ = getHeaderByNumber(*number, api, tx)
+	}
+	// Ensure we have an actually valid block
+	if header == nil {
+		return nil, errUnknownBlock
+	}
+	author, err := author(api, tx, header)
+	return &author, err
+}
+
+// GetSnapshotAtHash retrieves the state snapshot at a given block.
+func (api *BorImpl) GetSnapshotAtHash(hash common.Hash) (*Snapshot, error) {
+	ctx := context.Background()
+	tx, err := api.db.BeginRo(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+	header, _ := getHeaderByHash(tx, hash)
+	if header == nil {
+		return nil, errUnknownBlock
+	}
+	return snapshot(api, tx, header.Number.Uint64(), header.Hash())
+}
+
+// GetSigners retrieves the list of authorized signers at the specified block.
+func (api *BorImpl) GetSigners(number *rpc.BlockNumber) ([]common.Address, error) {
+	ctx := context.Background()
+	tx, err := api.db.BeginRo(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	// Retrieve the requested block number (or current if none requested)
+	var header *types.Header
+	if number == nil || *number == rpc.LatestBlockNumber {
+		header = rawdb.ReadCurrentHeader(tx)
+	} else {
+		header, _ = getHeaderByNumber(*number, api, tx)
+	}
+	// Ensure we have an actually valid block and return its snapshot
+	if header == nil {
+		return nil, errUnknownBlock
+	}
+	snap, err := snapshot(api, tx, header.Number.Uint64(), header.Hash())
+	return signers(snap.ValidatorSet), err
+}
+
+// GetSignersAtHash retrieves the list of authorized signers at the specified block.
+func (api *BorImpl) GetSignersAtHash(hash common.Hash) ([]common.Address, error) {
+	ctx := context.Background()
+	tx, err := api.db.BeginRo(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+	header, _ := getHeaderByHash(tx, hash)
+	if header == nil {
+		return nil, errUnknownBlock
+	}
+	snap, err := snapshot(api, tx, header.Number.Uint64(), header.Hash())
+	if err != nil {
+		return nil, err
+	}
+	return signers(snap.ValidatorSet), nil
+}
+
+// GetCurrentProposer gets the current proposer
+func (api *BorImpl) GetCurrentProposer() (common.Address, error) {
+	snap, err := api.GetSnapshot(nil)
+	if err != nil {
+		return common.Address{}, err
+	}
+	return getProposer(snap.ValidatorSet).Address, nil
+}
+
+// GetCurrentValidators gets the current validators
+func (api *BorImpl) GetCurrentValidators() ([]*bor.Validator, error) {
+	snap, err := api.GetSnapshot(nil)
+	if err != nil {
+		return make([]*bor.Validator, 0), err
+	}
+	return snap.ValidatorSet.Validators, nil
+}
+
+// GetRootHash returns the merkle root of the start to end block headers
+func (api *BorImpl) GetRootHash(start, end uint64) (string, error) {
+	length := uint64(end - start + 1)
+	if length > bor.MaxCheckpointLength {
+		return "", &bor.MaxCheckpointLengthExceededError{start, end}
+	}
+	ctx := context.Background()
+	tx, err := api.db.BeginRo(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer tx.Rollback()
+	currentHeaderNumber := rawdb.ReadCurrentHeader(tx).Number.Uint64()
+	if start > end || end > currentHeaderNumber {
+		return "", &bor.InvalidStartEndBlockError{start, end, currentHeaderNumber}
+	}
+	blockHeaders := make([]*types.Header, end-start+1)
+	wg := new(sync.WaitGroup)
+	concurrent := make(chan bool, 20)
+	for i := start; i <= end; i++ {
+		wg.Add(1)
+		concurrent <- true
+		go func(number uint64) {
+			blockHeaders[number-start], _ = getHeaderByNumber(rpc.BlockNumber(number), api, tx)
+			<-concurrent
+			wg.Done()
+		}(i)
+	}
+	wg.Wait()
+	close(concurrent)
+
+	headers := make([][32]byte, nextPowerOfTwo(length))
+	for i := 0; i < len(blockHeaders); i++ {
+		blockHeader := blockHeaders[i]
+		header := crypto.Keccak256(appendBytes32(
+			blockHeader.Number.Bytes(),
+			new(big.Int).SetUint64(blockHeader.Time).Bytes(),
+			blockHeader.TxHash.Bytes(),
+			blockHeader.ReceiptHash.Bytes(),
+		))
+
+		var arr [32]byte
+		copy(arr[:], header)
+		headers[i] = arr
+	}
+	tree := merkle.NewTreeWithOpts(merkle.TreeOptions{EnableHashSorting: false, DisableHashLeaves: true})
+	if err := tree.Generate(convert(headers), sha3.NewLegacyKeccak256()); err != nil {
+		return "", err
+	}
+	root := hex.EncodeToString(tree.Root().Hash)
+	return root, nil
+}
+
+func (api *BorImpl) Test() (string, error) {
+	return "Hello World", nil
+}
+
+// helper functions
+
+// getHeaderByNumber returns a block's header given a block number ignoring the block's transaction and uncle list (may be faster).
+// derived from erigon_getHeaderByNumber implementation (see ./erigon_block.go)
+func getHeaderByNumber(number rpc.BlockNumber, api *BorImpl, tx kv.Tx) (*types.Header, error) {
+	// Pending block is only known by the miner
+	if number == rpc.PendingBlockNumber {
+		block := api.pendingBlock()
+		if block == nil {
+			return nil, nil
+		}
+		return block.Header(), nil
+	}
+
+	blockNum, err := getBlockNumber(number, tx)
+	if err != nil {
+		return nil, err
+	}
+
+	header := rawdb.ReadHeaderByNumber(tx, blockNum)
+	if header == nil {
+		return nil, fmt.Errorf("block header not found: %d", blockNum)
+	}
+
+	return header, nil
+}
+
+// snapshot retrieves the authorization snapshot at a given point in time.
+func snapshot(api *BorImpl, tx kv.Tx, number uint64, hash common.Hash) (*Snapshot, error) {
+	var snap *Snapshot
+	// load on-disk checkpoints
+	if s, err := loadSnapshot(api, tx, hash); err == nil {
+		snap = s
+		return snap, nil
+	} else {
+		return nil, fmt.Errorf("unknown error while retrieving snapshot at block number %v", number)
+	}
+}
+
+// loadSnapshot loads an existing snapshot from the database.
+func loadSnapshot(api *BorImpl, tx kv.Tx, hash common.Hash) (*Snapshot, error) {
+	blob, err := tx.GetOne(kv.CliqueSeparate, append([]byte("bor-"), hash[:]...))
+	if err != nil {
+		return nil, err
+	}
+	snap := new(Snapshot)
+	if err := json.Unmarshal(blob, snap); err != nil {
+		return nil, err
+	}
+	config, _ := api.BaseAPI.chainConfig(tx)
+	snap.config = config.Bor
+
+	// update total voting power
+	if err := updateTotalVotingPower(snap.ValidatorSet); err != nil {
+		return nil, err
+	}
+
+	return snap, nil
+}
+
+// signers retrieves the list of authorized signers in ascending order.
+func signers(vals *ValidatorSet) []common.Address {
+	sigs := make([]common.Address, 0, len(vals.Validators))
+	for _, sig := range vals.Validators {
+		sigs = append(sigs, sig.Address)
+	}
+	return sigs
+}
+
+// Force recalculation of the set's total voting power.
+func updateTotalVotingPower(vals *ValidatorSet) error {
+
+	sum := int64(0)
+	for _, val := range vals.Validators {
+		// mind overflow
+		sum = safeAddClip(sum, val.VotingPower)
+		if sum > bor.MaxTotalVotingPower {
+			return &bor.TotalVotingPowerExceededError{sum, vals.Validators}
+		}
+	}
+	vals.totalVotingPower = sum
+	return nil
+}
+
+// getHeaderByHash returns a block's header given a block's hash.
+// derived from erigon_getHeaderByHash implementation (see ./erigon_block.go)
+func getHeaderByHash(tx kv.Tx, hash common.Hash) (*types.Header, error) {
+	header, err := rawdb.ReadHeaderByHash(tx, hash)
+	if err != nil {
+		return nil, err
+	}
+	if header == nil {
+		return nil, fmt.Errorf("block header not found: %s", hash.String())
+	}
+
+	return header, nil
+}
+
+// getProposer returns the current proposer.
+// If the validator set is empty, nil is returned.
+func getProposer(vals *ValidatorSet) (proposer *bor.Validator) {
+	if len(vals.Validators) == 0 {
+		return nil
+	}
+	if vals.Proposer == nil {
+		vals.Proposer = findProposer(vals)
+	}
+	return vals.Proposer.Copy()
+}
+
+func findProposer(vals *ValidatorSet) *bor.Validator {
+	var proposer *bor.Validator
+	for _, val := range vals.Validators {
+		if proposer == nil || !bytes.Equal(val.Address.Bytes(), proposer.Address.Bytes()) {
+			proposer = proposer.Cmp(val)
+		}
+	}
+	return proposer
+}
+
+// author returns the Ethereum address recovered
+// from the signature in the header's extra-data section.
+func author(api *BorImpl, tx kv.Tx, header *types.Header) (common.Address, error) {
+	config, _ := api.BaseAPI.chainConfig(tx)
+	return ecrecover(header, config.Bor)
+}
+
+// ecrecover extracts the Ethereum account address from a signed header.
+func ecrecover(header *types.Header, c *params.BorConfig) (common.Address, error) {
+	// Retrieve the signature from the header extra-data
+	if len(header.Extra) < extraSeal {
+		return common.Address{}, errMissingSignature
+	}
+	signature := header.Extra[len(header.Extra)-extraSeal:]
+
+	// Recover the public key and the Ethereum address
+	pubkey, err := crypto.Ecrecover(bor.SealHash(header, c).Bytes(), signature)
+	if err != nil {
+		return common.Address{}, err
+	}
+	var signer common.Address
+	copy(signer[:], crypto.Keccak256(pubkey[1:])[12:])
+
+	return signer, nil
+}
+
+// safe addition
+func safeAdd(a, b int64) (int64, bool) {
+	if b > 0 && a > math.MaxInt64-b {
+		return -1, true
+	} else if b < 0 && a < math.MinInt64-b {
+		return -1, true
+	}
+	return a + b, false
+}
+
+func safeAddClip(a, b int64) int64 {
+	c, overflow := safeAdd(a, b)
+	if overflow {
+		if b < 0 {
+			return math.MinInt64
+		}
+		return math.MaxInt64
+	}
+	return c
+}

--- a/cmd/rpcdaemon/commands/daemon.go
+++ b/cmd/rpcdaemon/commands/daemon.go
@@ -14,11 +14,18 @@ import (
 )
 
 // APIList describes the list of available RPC apis
-func APIList(ctx context.Context, db kv.RoDB,
-	eth services.ApiBackend, txPool txpool.TxpoolClient, mining txpool.MiningClient, filters *filters.Filters,
+func APIList(
+	ctx context.Context,
+	db kv.RoDB,
+	borDb kv.RoDB,
+	eth services.ApiBackend,
+	txPool txpool.TxpoolClient,
+	mining txpool.MiningClient,
+	filters *filters.Filters,
 	stateCache kvcache.Cache,
 	blockReader interfaces.BlockReader,
-	cfg cli.Flags, customAPIList []rpc.API) []rpc.API {
+	cfg cli.Flags, customAPIList []rpc.API,
+) []rpc.API {
 	var defaultAPIList []rpc.API
 
 	base := NewBaseApi(filters, stateCache, blockReader, cfg.SingleNodeMode)
@@ -34,7 +41,7 @@ func APIList(ctx context.Context, db kv.RoDB,
 	web3Impl := NewWeb3APIImpl(eth)
 	dbImpl := NewDBAPIImpl() /* deprecated */
 	engineImpl := NewEngineAPI(base, db)
-	borImpl := NewBorAPI(base, db)
+	borImpl := NewBorAPI(base, db, borDb) // bor (consensus) specific
 
 	for _, enabledAPI := range cfg.API {
 		switch enabledAPI {

--- a/cmd/rpcdaemon/commands/daemon.go
+++ b/cmd/rpcdaemon/commands/daemon.go
@@ -34,6 +34,7 @@ func APIList(ctx context.Context, db kv.RoDB,
 	web3Impl := NewWeb3APIImpl(eth)
 	dbImpl := NewDBAPIImpl() /* deprecated */
 	engineImpl := NewEngineAPI(base, db)
+	borImpl := NewBorAPI(base, db)
 
 	for _, enabledAPI := range cfg.API {
 		switch enabledAPI {
@@ -98,6 +99,13 @@ func APIList(ctx context.Context, db kv.RoDB,
 				Namespace: "engine",
 				Public:    true,
 				Service:   EngineAPI(engineImpl),
+				Version:   "1.0",
+			})
+		case "bor":
+			defaultAPIList = append(defaultAPIList, rpc.API{
+				Namespace: "bor",
+				Public:    true,
+				Service:   BorAPI(borImpl),
 				Version:   "1.0",
 			})
 		}

--- a/cmd/rpcdaemon/commands/merkle.go
+++ b/cmd/rpcdaemon/commands/merkle.go
@@ -1,0 +1,48 @@
+package commands
+
+func appendBytes32(data ...[]byte) []byte {
+	var result []byte
+	for _, v := range data {
+		paddedV, err := convertTo32(v)
+		if err == nil {
+			result = append(result, paddedV[:]...)
+		}
+	}
+	return result
+}
+
+func nextPowerOfTwo(n uint64) uint64 {
+	if n == 0 {
+		return 1
+	}
+	// http://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
+	n--
+	n |= n >> 1
+	n |= n >> 2
+	n |= n >> 4
+	n |= n >> 8
+	n |= n >> 16
+	n |= n >> 32
+	n++
+	return n
+}
+
+func convertTo32(input []byte) (output [32]byte, err error) {
+	l := len(input)
+	if l > 32 || l == 0 {
+		return
+	}
+	copy(output[32-l:], input[:])
+	return
+}
+
+func convert(input []([32]byte)) [][]byte {
+	var output [][]byte
+	for _, in := range input {
+		newInput := make([]byte, len(in[:]))
+		copy(newInput, in[:])
+		output = append(output, newInput)
+
+	}
+	return output
+}

--- a/cmd/rpcdaemon/commands/validator_set.go
+++ b/cmd/rpcdaemon/commands/validator_set.go
@@ -1,0 +1,704 @@
+package commands
+
+// Tendermint leader selection algorithm
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/big"
+	"sort"
+	"strings"
+
+	"github.com/ledgerwatch/erigon/common"
+	"github.com/ledgerwatch/erigon/consensus/bor"
+	"github.com/ledgerwatch/log/v3"
+)
+
+// MaxTotalVotingPower - the maximum allowed total voting power.
+// It needs to be sufficiently small to, in all cases:
+// 1. prevent clipping in incrementProposerPriority()
+// 2. let (diff+diffMax-1) not overflow in IncrementProposerPriority()
+// (Proof of 1 is tricky, left to the reader).
+// It could be higher, but this is sufficiently large for our purposes,
+// and leaves room for defensive purposes.
+// PriorityWindowSizeFactor - is a constant that when multiplied with the total voting power gives
+// the maximum allowed distance between validator priorities.
+
+const (
+	MaxTotalVotingPower      = int64(math.MaxInt64) / 8
+	PriorityWindowSizeFactor = 2
+)
+
+// ValidatorSet represent a set of *Validator at a given height.
+// The validators can be fetched by address or index.
+// The index is in order of .Address, so the indices are fixed
+// for all rounds of a given blockchain height - ie. the validators
+// are sorted by their address.
+// On the other hand, the .ProposerPriority of each validator and
+// the designated .GetProposer() of a set changes every round,
+// upon calling .IncrementProposerPriority().
+// NOTE: Not goroutine-safe.
+// NOTE: All get/set to validators should copy the value for safety.
+type ValidatorSet struct {
+	// NOTE: persisted via reflect, must be exported.
+	Validators []*bor.Validator `json:"validators"`
+	Proposer   *bor.Validator   `json:"proposer"`
+
+	// cached (unexported)
+	totalVotingPower int64
+}
+
+// NewValidatorSet initializes a ValidatorSet by copying over the
+// values from `valz`, a list of Validators. If valz is nil or empty,
+// the new ValidatorSet will have an empty list of Validators.
+// The addresses of validators in `valz` must be unique otherwise the
+// function panics.
+func NewValidatorSet(valz []*bor.Validator) *ValidatorSet {
+	vals := &ValidatorSet{}
+	err := vals.updateWithChangeSet(valz, false)
+	if err != nil {
+		panic(fmt.Sprintf("cannot create validator set: %s", err))
+	}
+	if len(valz) > 0 {
+		vals.IncrementProposerPriority(1)
+	}
+	return vals
+}
+
+// Nil or empty validator sets are invalid.
+func (vals *ValidatorSet) IsNilOrEmpty() bool {
+	return vals == nil || len(vals.Validators) == 0
+}
+
+// Increment ProposerPriority and update the proposer on a copy, and return it.
+func (vals *ValidatorSet) CopyIncrementProposerPriority(times int) *ValidatorSet {
+	copy := vals.Copy()
+	copy.IncrementProposerPriority(times)
+	return copy
+}
+
+// IncrementProposerPriority increments ProposerPriority of each validator and updates the
+// proposer. Panics if validator set is empty.
+// `times` must be positive.
+func (vals *ValidatorSet) IncrementProposerPriority(times int) {
+	if vals.IsNilOrEmpty() {
+		panic("empty validator set")
+	}
+	if times <= 0 {
+		panic("Cannot call IncrementProposerPriority with non-positive times")
+	}
+
+	// Cap the difference between priorities to be proportional to 2*totalPower by
+	// re-normalizing priorities, i.e., rescale all priorities by multiplying with:
+	//  2*totalVotingPower/(maxPriority - minPriority)
+	diffMax := PriorityWindowSizeFactor * vals.TotalVotingPower()
+	vals.RescalePriorities(diffMax)
+	vals.shiftByAvgProposerPriority()
+
+	var proposer *bor.Validator
+	// Call IncrementProposerPriority(1) times times.
+	for i := 0; i < times; i++ {
+		proposer = vals.incrementProposerPriority()
+	}
+
+	vals.Proposer = proposer
+}
+
+func (vals *ValidatorSet) RescalePriorities(diffMax int64) {
+	if vals.IsNilOrEmpty() {
+		panic("empty validator set")
+	}
+	// NOTE: This check is merely a sanity check which could be
+	// removed if all tests would init. voting power appropriately;
+	// i.e. diffMax should always be > 0
+	if diffMax <= 0 {
+		return
+	}
+
+	// Calculating ceil(diff/diffMax):
+	// Re-normalization is performed by dividing by an integer for simplicity.
+	// NOTE: This may make debugging priority issues easier as well.
+	diff := computeMaxMinPriorityDiff(vals)
+	ratio := (diff + diffMax - 1) / diffMax
+	if diff > diffMax {
+		for _, val := range vals.Validators {
+			val.ProposerPriority = val.ProposerPriority / ratio
+		}
+	}
+}
+
+func (vals *ValidatorSet) incrementProposerPriority() *bor.Validator {
+	for _, val := range vals.Validators {
+		// Check for overflow for sum.
+		newPrio := safeAddClip(val.ProposerPriority, val.VotingPower)
+		val.ProposerPriority = newPrio
+	}
+	// Decrement the validator with most ProposerPriority.
+	mostest := vals.getValWithMostPriority()
+	// Mind the underflow.
+	mostest.ProposerPriority = safeSubClip(mostest.ProposerPriority, vals.TotalVotingPower())
+
+	return mostest
+}
+
+// Should not be called on an empty validator set.
+func (vals *ValidatorSet) computeAvgProposerPriority() int64 {
+	n := int64(len(vals.Validators))
+	sum := big.NewInt(0)
+	for _, val := range vals.Validators {
+		sum.Add(sum, big.NewInt(val.ProposerPriority))
+	}
+	avg := sum.Div(sum, big.NewInt(n))
+	if avg.IsInt64() {
+		return avg.Int64()
+	}
+
+	// This should never happen: each val.ProposerPriority is in bounds of int64.
+	panic(fmt.Sprintf("Cannot represent avg ProposerPriority as an int64 %v", avg))
+}
+
+// Compute the difference between the max and min ProposerPriority of that set.
+func computeMaxMinPriorityDiff(vals *ValidatorSet) int64 {
+	if vals.IsNilOrEmpty() {
+		panic("empty validator set")
+	}
+	max := int64(math.MinInt64)
+	min := int64(math.MaxInt64)
+	for _, v := range vals.Validators {
+		if v.ProposerPriority < min {
+			min = v.ProposerPriority
+		}
+		if v.ProposerPriority > max {
+			max = v.ProposerPriority
+		}
+	}
+	diff := max - min
+	if diff < 0 {
+		return -1 * diff
+	} else {
+		return diff
+	}
+}
+
+func (vals *ValidatorSet) getValWithMostPriority() *bor.Validator {
+	var res *bor.Validator
+	for _, val := range vals.Validators {
+		res = res.Cmp(val)
+	}
+	return res
+}
+
+func (vals *ValidatorSet) shiftByAvgProposerPriority() {
+	if vals.IsNilOrEmpty() {
+		panic("empty validator set")
+	}
+	avgProposerPriority := vals.computeAvgProposerPriority()
+	for _, val := range vals.Validators {
+		val.ProposerPriority = safeSubClip(val.ProposerPriority, avgProposerPriority)
+	}
+}
+
+// Makes a copy of the validator list.
+func validatorListCopy(valsList []*bor.Validator) []*bor.Validator {
+	if valsList == nil {
+		return nil
+	}
+	valsCopy := make([]*bor.Validator, len(valsList))
+	for i, val := range valsList {
+		valsCopy[i] = val.Copy()
+	}
+	return valsCopy
+}
+
+// Copy each validator into a new ValidatorSet.
+func (vals *ValidatorSet) Copy() *ValidatorSet {
+	return &ValidatorSet{
+		Validators:       validatorListCopy(vals.Validators),
+		Proposer:         vals.Proposer,
+		totalVotingPower: vals.totalVotingPower,
+	}
+}
+
+// HasAddress returns true if address given is in the validator set, false -
+// otherwise.
+func (vals *ValidatorSet) HasAddress(address []byte) bool {
+	idx := sort.Search(len(vals.Validators), func(i int) bool {
+		return bytes.Compare(address, vals.Validators[i].Address.Bytes()) <= 0
+	})
+	return idx < len(vals.Validators) && bytes.Equal(vals.Validators[idx].Address.Bytes(), address)
+}
+
+// GetByAddress returns an index of the validator with address and validator
+// itself if found. Otherwise, -1 and nil are returned.
+func (vals *ValidatorSet) GetByAddress(address common.Address) (index int, val *bor.Validator) {
+	idx := sort.Search(len(vals.Validators), func(i int) bool {
+		return bytes.Compare(address.Bytes(), vals.Validators[i].Address.Bytes()) <= 0
+	})
+	if idx < len(vals.Validators) && bytes.Equal(vals.Validators[idx].Address.Bytes(), address.Bytes()) {
+		return idx, vals.Validators[idx].Copy()
+	}
+	return -1, nil
+}
+
+// GetByIndex returns the validator's address and validator itself by index.
+// It returns nil values if index is less than 0 or greater or equal to
+// len(ValidatorSet.Validators).
+func (vals *ValidatorSet) GetByIndex(index int) (address []byte, val *bor.Validator) {
+	if index < 0 || index >= len(vals.Validators) {
+		return nil, nil
+	}
+	val = vals.Validators[index]
+	return val.Address.Bytes(), val.Copy()
+}
+
+// Size returns the length of the validator set.
+func (vals *ValidatorSet) Size() int {
+	return len(vals.Validators)
+}
+
+// Force recalculation of the set's total voting power.
+func (vals *ValidatorSet) updateTotalVotingPower() error {
+
+	sum := int64(0)
+	for _, val := range vals.Validators {
+		// mind overflow
+		sum = safeAddClip(sum, val.VotingPower)
+		if sum > MaxTotalVotingPower {
+			return &bor.TotalVotingPowerExceededError{sum, vals.Validators}
+		}
+	}
+	vals.totalVotingPower = sum
+	return nil
+}
+
+// TotalVotingPower returns the sum of the voting powers of all validators.
+// It recomputes the total voting power if required.
+func (vals *ValidatorSet) TotalVotingPower() int64 {
+	if vals.totalVotingPower == 0 {
+		log.Info("invoking updateTotalVotingPower before returning it")
+		if err := vals.updateTotalVotingPower(); err != nil {
+			// Can/should we do better?
+			panic(err)
+		}
+	}
+	return vals.totalVotingPower
+}
+
+// GetProposer returns the current proposer. If the validator set is empty, nil
+// is returned.
+func (vals *ValidatorSet) GetProposer() (proposer *bor.Validator) {
+	if len(vals.Validators) == 0 {
+		return nil
+	}
+	if vals.Proposer == nil {
+		vals.Proposer = vals.findProposer()
+	}
+	return vals.Proposer.Copy()
+}
+
+func (vals *ValidatorSet) findProposer() *bor.Validator {
+	var proposer *bor.Validator
+	for _, val := range vals.Validators {
+		if proposer == nil || !bytes.Equal(val.Address.Bytes(), proposer.Address.Bytes()) {
+			proposer = proposer.Cmp(val)
+		}
+	}
+	return proposer
+}
+
+// Hash returns the Merkle root hash build using validators (as leaves) in the
+// set.
+// func (vals *ValidatorSet) Hash() []byte {
+// 	if len(vals.Validators) == 0 {
+// 		return nil
+// 	}
+// 	bzs := make([][]byte, len(vals.Validators))
+// 	for i, val := range vals.Validators {
+// 		bzs[i] = val.Bytes()
+// 	}
+// 	return merkle.SimpleHashFromByteSlices(bzs)
+// }
+
+// Iterate will run the given function over the set.
+func (vals *ValidatorSet) Iterate(fn func(index int, val *bor.Validator) bool) {
+	for i, val := range vals.Validators {
+		stop := fn(i, val.Copy())
+		if stop {
+			break
+		}
+	}
+}
+
+// Checks changes against duplicates, splits the changes in updates and removals, sorts them by address.
+//
+// Returns:
+// updates, removals - the sorted lists of updates and removals
+// err - non-nil if duplicate entries or entries with negative voting power are seen
+//
+// No changes are made to 'origChanges'.
+func processChanges(origChanges []*bor.Validator) (updates, removals []*bor.Validator, err error) {
+	// Make a deep copy of the changes and sort by address.
+	changes := validatorListCopy(origChanges)
+	sort.Sort(ValidatorsByAddress(changes))
+
+	removals = make([]*bor.Validator, 0, len(changes))
+	updates = make([]*bor.Validator, 0, len(changes))
+	var prevAddr common.Address
+
+	// Scan changes by address and append valid validators to updates or removals lists.
+	for _, valUpdate := range changes {
+		if bytes.Equal(valUpdate.Address.Bytes(), prevAddr.Bytes()) {
+			err = fmt.Errorf("duplicate entry %v in %v", valUpdate, changes)
+			return nil, nil, err
+		}
+		if valUpdate.VotingPower < 0 {
+			err = fmt.Errorf("voting power can't be negative: %v", valUpdate)
+			return nil, nil, err
+		}
+		if valUpdate.VotingPower > MaxTotalVotingPower {
+			err = fmt.Errorf("to prevent clipping/ overflow, voting power can't be higher than %v: %v ",
+				MaxTotalVotingPower, valUpdate)
+			return nil, nil, err
+		}
+		if valUpdate.VotingPower == 0 {
+			removals = append(removals, valUpdate)
+		} else {
+			updates = append(updates, valUpdate)
+		}
+		prevAddr = valUpdate.Address
+	}
+	return updates, removals, err
+}
+
+// Verifies a list of updates against a validator set, making sure the allowed
+// total voting power would not be exceeded if these updates would be applied to the set.
+//
+// Returns:
+// updatedTotalVotingPower - the new total voting power if these updates would be applied
+// numNewValidators - number of new validators
+// err - non-nil if the maximum allowed total voting power would be exceeded
+//
+// 'updates' should be a list of proper validator changes, i.e. they have been verified
+// by processChanges for duplicates and invalid values.
+// No changes are made to the validator set 'vals'.
+func verifyUpdates(updates []*bor.Validator, vals *ValidatorSet) (updatedTotalVotingPower int64, numNewValidators int, err error) {
+
+	updatedTotalVotingPower = vals.TotalVotingPower()
+
+	for _, valUpdate := range updates {
+		address := valUpdate.Address
+		_, val := vals.GetByAddress(address)
+		if val == nil {
+			// New validator, add its voting power the the total.
+			updatedTotalVotingPower += valUpdate.VotingPower
+			numNewValidators++
+		} else {
+			// Updated validator, add the difference in power to the total.
+			updatedTotalVotingPower += valUpdate.VotingPower - val.VotingPower
+		}
+		overflow := updatedTotalVotingPower > MaxTotalVotingPower
+		if overflow {
+			err = fmt.Errorf(
+				"failed to add/update validator %v, total voting power would exceed the max allowed %v",
+				valUpdate, MaxTotalVotingPower)
+			return 0, 0, err
+		}
+	}
+
+	return updatedTotalVotingPower, numNewValidators, nil
+}
+
+// Computes the proposer priority for the validators not present in the set based on 'updatedTotalVotingPower'.
+// Leaves unchanged the priorities of validators that are changed.
+//
+// 'updates' parameter must be a list of unique validators to be added or updated.
+// No changes are made to the validator set 'vals'.
+func computeNewPriorities(updates []*bor.Validator, vals *ValidatorSet, updatedTotalVotingPower int64) {
+
+	for _, valUpdate := range updates {
+		address := valUpdate.Address
+		_, val := vals.GetByAddress(address)
+		if val == nil {
+			// add val
+			// Set ProposerPriority to -C*totalVotingPower (with C ~= 1.125) to make sure validators can't
+			// un-bond and then re-bond to reset their (potentially previously negative) ProposerPriority to zero.
+			//
+			// Contract: updatedVotingPower < MaxTotalVotingPower to ensure ProposerPriority does
+			// not exceed the bounds of int64.
+			//
+			// Compute ProposerPriority = -1.125*totalVotingPower == -(updatedVotingPower + (updatedVotingPower >> 3)).
+			valUpdate.ProposerPriority = -(updatedTotalVotingPower + (updatedTotalVotingPower >> 3))
+		} else {
+			valUpdate.ProposerPriority = val.ProposerPriority
+		}
+	}
+
+}
+
+// Merges the vals' validator list with the updates list.
+// When two elements with same address are seen, the one from updates is selected.
+// Expects updates to be a list of updates sorted by address with no duplicates or errors,
+// must have been validated with verifyUpdates() and priorities computed with computeNewPriorities().
+func (vals *ValidatorSet) applyUpdates(updates []*bor.Validator) {
+
+	existing := vals.Validators
+	merged := make([]*bor.Validator, len(existing)+len(updates))
+	i := 0
+
+	for len(existing) > 0 && len(updates) > 0 {
+		if bytes.Compare(existing[0].Address.Bytes(), updates[0].Address.Bytes()) < 0 { // unchanged validator
+			merged[i] = existing[0]
+			existing = existing[1:]
+		} else {
+			// Apply add or update.
+			merged[i] = updates[0]
+			if bytes.Equal(existing[0].Address.Bytes(), updates[0].Address.Bytes()) {
+				// bor.Validator is present in both, advance existing.
+				existing = existing[1:]
+			}
+			updates = updates[1:]
+		}
+		i++
+	}
+
+	// Add the elements which are left.
+	for j := 0; j < len(existing); j++ {
+		merged[i] = existing[j]
+		i++
+	}
+	// OR add updates which are left.
+	for j := 0; j < len(updates); j++ {
+		merged[i] = updates[j]
+		i++
+	}
+
+	vals.Validators = merged[:i]
+}
+
+// Checks that the validators to be removed are part of the validator set.
+// No changes are made to the validator set 'vals'.
+func verifyRemovals(deletes []*bor.Validator, vals *ValidatorSet) error {
+
+	for _, valUpdate := range deletes {
+		address := valUpdate.Address
+		_, val := vals.GetByAddress(address)
+		if val == nil {
+			return fmt.Errorf("failed to find validator %X to remove", address)
+		}
+	}
+	if len(deletes) > len(vals.Validators) {
+		panic("more deletes than validators")
+	}
+	return nil
+}
+
+// Removes the validators specified in 'deletes' from validator set 'vals'.
+// Should not fail as verification has been done before.
+func (vals *ValidatorSet) applyRemovals(deletes []*bor.Validator) {
+
+	existing := vals.Validators
+
+	merged := make([]*bor.Validator, len(existing)-len(deletes))
+	i := 0
+
+	// Loop over deletes until we removed all of them.
+	for len(deletes) > 0 {
+		if bytes.Equal(existing[0].Address.Bytes(), deletes[0].Address.Bytes()) {
+			deletes = deletes[1:]
+		} else { // Leave it in the resulting slice.
+			merged[i] = existing[0]
+			i++
+		}
+		existing = existing[1:]
+	}
+
+	// Add the elements which are left.
+	for j := 0; j < len(existing); j++ {
+		merged[i] = existing[j]
+		i++
+	}
+
+	vals.Validators = merged[:i]
+}
+
+// Main function used by UpdateWithChangeSet() and NewValidatorSet().
+// If 'allowDeletes' is false then delete operations (identified by validators with voting power 0)
+// are not allowed and will trigger an error if present in 'changes'.
+// The 'allowDeletes' flag is set to false by NewValidatorSet() and to true by UpdateWithChangeSet().
+func (vals *ValidatorSet) updateWithChangeSet(changes []*bor.Validator, allowDeletes bool) error {
+
+	if len(changes) <= 0 {
+		return nil
+	}
+
+	// Check for duplicates within changes, split in 'updates' and 'deletes' lists (sorted).
+	updates, deletes, err := processChanges(changes)
+	if err != nil {
+		return err
+	}
+
+	if !allowDeletes && len(deletes) != 0 {
+		return fmt.Errorf("cannot process validators with voting power 0: %v", deletes)
+	}
+
+	// Verify that applying the 'deletes' against 'vals' will not result in error.
+	if err := verifyRemovals(deletes, vals); err != nil {
+		return err
+	}
+
+	// Verify that applying the 'updates' against 'vals' will not result in error.
+	updatedTotalVotingPower, numNewValidators, err := verifyUpdates(updates, vals)
+	if err != nil {
+		return err
+	}
+
+	// Check that the resulting set will not be empty.
+	if numNewValidators == 0 && len(vals.Validators) == len(deletes) {
+		return fmt.Errorf("applying the validator changes would result in empty set")
+	}
+
+	// Compute the priorities for updates.
+	computeNewPriorities(updates, vals, updatedTotalVotingPower)
+
+	// Apply updates and removals.
+	vals.applyUpdates(updates)
+	vals.applyRemovals(deletes)
+
+	if err := vals.updateTotalVotingPower(); err != nil {
+		return err
+	}
+
+	// Scale and center.
+	vals.RescalePriorities(PriorityWindowSizeFactor * vals.TotalVotingPower())
+	vals.shiftByAvgProposerPriority()
+
+	return nil
+}
+
+// UpdateWithChangeSet attempts to update the validator set with 'changes'.
+// It performs the following steps:
+// - validates the changes making sure there are no duplicates and splits them in updates and deletes
+// - verifies that applying the changes will not result in errors
+// - computes the total voting power BEFORE removals to ensure that in the next steps the priorities
+//   across old and newly added validators are fair
+// - computes the priorities of new validators against the final set
+// - applies the updates against the validator set
+// - applies the removals against the validator set
+// - performs scaling and centering of priority values
+// If an error is detected during verification steps, it is returned and the validator set
+// is not changed.
+func (vals *ValidatorSet) UpdateWithChangeSet(changes []*bor.Validator) error {
+	return vals.updateWithChangeSet(changes, true)
+}
+
+//-----------------
+// ErrTooMuchChange
+
+func IsErrTooMuchChange(err error) bool {
+	switch err.(type) {
+	case errTooMuchChange:
+		return true
+	default:
+		return false
+	}
+}
+
+type errTooMuchChange struct {
+	got    int64
+	needed int64
+}
+
+func (e errTooMuchChange) Error() string {
+	return fmt.Sprintf("Invalid commit -- insufficient old voting power: got %v, needed %v", e.got, e.needed)
+}
+
+//----------------
+
+func (vals *ValidatorSet) String() string {
+	return vals.StringIndented("")
+}
+
+func (vals *ValidatorSet) StringIndented(indent string) string {
+	if vals == nil {
+		return "nil-ValidatorSet"
+	}
+	var valStrings []string
+	vals.Iterate(func(index int, val *bor.Validator) bool {
+		valStrings = append(valStrings, val.String())
+		return false
+	})
+	return fmt.Sprintf(`ValidatorSet{
+%s  Proposer: %v
+%s  Validators:
+%s    %v
+%s}`,
+		indent, vals.GetProposer().String(),
+		indent,
+		indent, strings.Join(valStrings, "\n"+indent+"    "),
+		indent)
+
+}
+
+//-------------------------------------
+// Implements sort for sorting validators by address.
+
+// Sort validators by address.
+type ValidatorsByAddress []*bor.Validator
+
+func (valz ValidatorsByAddress) Len() int {
+	return len(valz)
+}
+
+func (valz ValidatorsByAddress) Less(i, j int) bool {
+	return bytes.Compare(valz[i].Address.Bytes(), valz[j].Address.Bytes()) == -1
+}
+
+func (valz ValidatorsByAddress) Swap(i, j int) {
+	it := valz[i]
+	valz[i] = valz[j]
+	valz[j] = it
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// safe addition/subtraction
+
+func safeAdd(a, b int64) (int64, bool) {
+	if b > 0 && a > math.MaxInt64-b {
+		return -1, true
+	} else if b < 0 && a < math.MinInt64-b {
+		return -1, true
+	}
+	return a + b, false
+}
+
+func safeSub(a, b int64) (int64, bool) {
+	if b > 0 && a < math.MinInt64+b {
+		return -1, true
+	} else if b < 0 && a > math.MaxInt64+b {
+		return -1, true
+	}
+	return a - b, false
+}
+
+func safeAddClip(a, b int64) int64 {
+	c, overflow := safeAdd(a, b)
+	if overflow {
+		if b < 0 {
+			return math.MinInt64
+		}
+		return math.MaxInt64
+	}
+	return c
+}
+
+func safeSubClip(a, b int64) int64 {
+	c, overflow := safeSub(a, b)
+	if overflow {
+		if b > 0 {
+			return math.MinInt64
+		}
+		return math.MaxInt64
+	}
+	return c
+}

--- a/cmd/rpcdaemon/main.go
+++ b/cmd/rpcdaemon/main.go
@@ -16,7 +16,7 @@ func main() {
 	rootCtx, rootCancel := utils.RootContext()
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		logger := log.New()
-		db, backend, txPool, mining, stateCache, blockReader, err := cli.RemoteServices(cmd.Context(), *cfg, logger, rootCancel)
+		db, borDb, backend, txPool, mining, stateCache, blockReader, err := cli.RemoteServices(cmd.Context(), *cfg, logger, rootCancel)
 		if err != nil {
 			log.Error("Could not connect to DB", "error", err)
 			return nil
@@ -30,7 +30,7 @@ func main() {
 			log.Info("filters are not supported in chaindata mode")
 		}
 
-		if err := cli.StartRpcServer(cmd.Context(), *cfg, commands.APIList(cmd.Context(), db, backend, txPool, mining, ff, stateCache, blockReader, *cfg, nil)); err != nil {
+		if err := cli.StartRpcServer(cmd.Context(), *cfg, commands.APIList(cmd.Context(), db, borDb, backend, txPool, mining, ff, stateCache, blockReader, *cfg, nil)); err != nil {
 			log.Error(err.Error())
 			return nil
 		}

--- a/consensus/db/db.go
+++ b/consensus/db/db.go
@@ -7,6 +7,7 @@ import (
 )
 
 func OpenDatabase(path string, logger log.Logger, inmem bool) kv.RwDB {
+	log.Info("Opening consensus db", "path", path, "in memory", inmem)
 	opts := mdbx.NewMDBX(logger)
 	if inmem {
 		opts = opts.InMem()

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -204,7 +204,7 @@ func New(stack *node.Node, config *ethconfig.Config, logger log.Logger) (*Ethere
 		consensusConfig = &config.Ethash
 	}
 
-	backend.engine = ethconfig.CreateConsensusEngine(chainConfig, logger, consensusConfig, config.Miner.Notify, config.Miner.Noverify, config.HeimdallURL, config.WithoutHeimdall)
+	backend.engine = ethconfig.CreateConsensusEngine(chainConfig, logger, consensusConfig, config.Miner.Notify, config.Miner.Noverify, config.HeimdallURL, config.WithoutHeimdall, stack.DataDir())
 
 	log.Info("Initialising Ethereum protocol", "network", config.NetworkID)
 

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/c2h5oh/datasize"
 	"github.com/davecgh/go-spew/spew"
-	"github.com/ledgerwatch/erigon/common/paths"
 	"github.com/ledgerwatch/erigon/consensus/aura"
 	"github.com/ledgerwatch/erigon/consensus/aura/consensusconfig"
 	"github.com/ledgerwatch/erigon/consensus/bor"
@@ -191,7 +190,7 @@ type Config struct {
 	WithoutHeimdall bool
 }
 
-func CreateConsensusEngine(chainConfig *params.ChainConfig, logger log.Logger, config interface{}, notify []string, noverify bool, HeimdallURL string, WithoutHeimdall bool) consensus.Engine {
+func CreateConsensusEngine(chainConfig *params.ChainConfig, logger log.Logger, config interface{}, notify []string, noverify bool, HeimdallURL string, WithoutHeimdall bool, dataDir string) consensus.Engine {
 	var eng consensus.Engine
 
 	switch consensusCfg := config.(type) {
@@ -232,7 +231,8 @@ func CreateConsensusEngine(chainConfig *params.ChainConfig, logger log.Logger, c
 
 	case *params.BorConfig:
 		if chainConfig.Bor != nil {
-			eng = bor.New(chainConfig, db.OpenDatabase(path.Join(paths.DefaultDataDir()+"bor"), logger, true), HeimdallURL, WithoutHeimdall)
+			borDbPath := path.Join(dataDir, "bor") // bor consensus path: datadir/bor
+			eng = bor.New(chainConfig, db.OpenDatabase(borDbPath, logger, false), HeimdallURL, WithoutHeimdall)
 		}
 	}
 

--- a/internal/web3ext/bor_ext.go
+++ b/internal/web3ext/bor_ext.go
@@ -1,0 +1,59 @@
+package web3ext
+
+// BorJs bor related apis
+const BorJs = `
+web3._extend({
+	property: 'bor',
+	methods: [
+		new web3._extend.Method({
+			name: 'getSnapshot',
+			call: 'bor_getSnapshot',
+			params: 1,
+			inputFormatter: [null]
+		}),
+		new web3._extend.Method({
+			name: 'getAuthor',
+			call: 'bor_getAuthor',
+			params: 1,
+			inputFormatter: [null]
+		}),
+		new web3._extend.Method({
+			name: 'getSnapshotAtHash',
+			call: 'bor_getSnapshotAtHash',
+			params: 1
+		}),
+		new web3._extend.Method({
+			name: 'getSigners',
+			call: 'bor_getSigners',
+			params: 1,
+			inputFormatter: [null]
+		}),
+		new web3._extend.Method({
+			name: 'getSignersAtHash',
+			call: 'bor_getSignersAtHash',
+			params: 1
+		}),
+		new web3._extend.Method({
+			name: 'getCurrentProposer',
+			call: 'bor_getCurrentProposer',
+			params: 0
+		}),
+		new web3._extend.Method({
+			name: 'getCurrentValidators',
+			call: 'bor_getCurrentValidators',
+			params: 0
+		}),
+		new web3._extend.Method({
+			name: 'getRootHash',
+			call: 'bor_getRootHash',
+			params: 2,
+		}),
+		new web3._extend.Method({
+			name: 'test',
+			call: 'bor_test',
+			params: 0,
+			inputFormatter: [null]
+		}),
+	]
+});
+`

--- a/internal/web3ext/bor_ext.go
+++ b/internal/web3ext/bor_ext.go
@@ -48,12 +48,6 @@ web3._extend({
 			call: 'bor_getRootHash',
 			params: 2,
 		}),
-		new web3._extend.Method({
-			name: 'test',
-			call: 'bor_test',
-			params: 0,
-			inputFormatter: [null]
-		}),
 	]
 });
 `

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -33,6 +33,7 @@ var Modules = map[string]string{
 	"txpool":     TxpoolJs,
 	"les":        LESJs,
 	"vflux":      VfluxJs,
+	"bor":        BorJs,
 }
 
 const ChequebookJs = `


### PR DESCRIPTION
This PR adds support for BOR consensus specific RPC methods in the erigon's rpcdaemon. 
The support for following 8 methods is added belonging to the `bor` namespace. 
- [x] GetSnapshot
- [x] GetAuthor
- [x] GetSnapshotAtHash
- [x] GetSigners
- [x] GetSignersAtHash
- [x] GetCurrentProposer
- [x] GetCurrentValidators
- [x] GetRootHash